### PR TITLE
geom_alt props

### DIFF
--- a/data/101/919/457/101919457.geojson
+++ b/data/101/919/457/101919457.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Budrus"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"55245d1031b7125ee6d696c69caefcdd",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101919457,
-    "wof:lastmodified":1566600576,
+    "wof:lastmodified":1582314142,
     "wof:name":"Budrus",
     "wof:parent_id":1091913137,
     "wof:placetype":"locality",

--- a/data/101/919/639/101919639.geojson
+++ b/data/101/919/639/101919639.geojson
@@ -459,6 +459,9 @@
         "wd:id":"Q47492"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"70f4928fd12089fc3f0e52202a6d4a2c",
     "wof:hierarchy":[
         {
@@ -481,7 +484,7 @@
         }
     ],
     "wof:id":101919639,
-    "wof:lastmodified":1566600575,
+    "wof:lastmodified":1582314141,
     "wof:name":"Gaza",
     "wof:parent_id":1091913297,
     "wof:placetype":"locality",

--- a/data/101/919/787/101919787.geojson
+++ b/data/101/919/787/101919787.geojson
@@ -73,6 +73,9 @@
         "wd:id":"Q4702782"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e9940e826c1c6504a0fc291c1558d981",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":101919787,
-    "wof:lastmodified":1566600580,
+    "wof:lastmodified":1582314142,
     "wof:name":"Al Majd",
     "wof:parent_id":1091912955,
     "wof:placetype":"locality",

--- a/data/101/920/009/101920009.geojson
+++ b/data/101/920/009/101920009.geojson
@@ -77,6 +77,9 @@
         "wd:id":"Q4702309"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"81599a3f8db970c7a57c75ba5e8571d7",
     "wof:hierarchy":[
         {
@@ -99,7 +102,7 @@
         }
     ],
     "wof:id":101920009,
-    "wof:lastmodified":1566600528,
+    "wof:lastmodified":1582314141,
     "wof:name":"Al Burj",
     "wof:parent_id":1091912955,
     "wof:placetype":"locality",

--- a/data/101/920/945/101920945.geojson
+++ b/data/101/920/945/101920945.geojson
@@ -102,6 +102,9 @@
         "wk:page":"Ya'bad"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"63b21eb57dfe8ea0f78b87ad831dfa45",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101920945,
-    "wof:lastmodified":1566600551,
+    "wof:lastmodified":1582314141,
     "wof:name":"Ya'bad",
     "wof:parent_id":1091912973,
     "wof:placetype":"locality",

--- a/data/101/920/983/101920983.geojson
+++ b/data/101/920/983/101920983.geojson
@@ -60,6 +60,9 @@
         "qs_pg:id":124008
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"26d148911ddf9e537ddf2fa721d8ecc6",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":101920983,
-    "wof:lastmodified":1566600531,
+    "wof:lastmodified":1582314141,
     "wof:name":"Al Mughayyir",
     "wof:parent_id":1091912973,
     "wof:placetype":"locality",

--- a/data/101/921/019/101921019.geojson
+++ b/data/101/921/019/101921019.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Qabatiya"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ddbe9a0b12040aeb6b81a07a89457732",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":101921019,
-    "wof:lastmodified":1566600608,
+    "wof:lastmodified":1582314142,
     "wof:name":"Qabatiya",
     "wof:parent_id":1091912973,
     "wof:placetype":"locality",

--- a/data/101/921/161/101921161.geojson
+++ b/data/101/921/161/101921161.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Bal'a"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"65f2536582f2c985383ae4c39c52266a",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":101921161,
-    "wof:lastmodified":1566600584,
+    "wof:lastmodified":1582314142,
     "wof:name":"Bal'a",
     "wof:parent_id":1091913233,
     "wof:placetype":"locality",

--- a/data/101/921/185/101921185.geojson
+++ b/data/101/921/185/101921185.geojson
@@ -58,6 +58,9 @@
         "wd:id":"Q357840"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"6d6994384fd77b24d7cda36c02b8cc6d",
     "wof:hierarchy":[
         {
@@ -70,7 +73,7 @@
         }
     ],
     "wof:id":101921185,
-    "wof:lastmodified":1534985973,
+    "wof:lastmodified":1582314143,
     "wof:name":"Jaba'",
     "wof:parent_id":1091912973,
     "wof:placetype":"locality",

--- a/data/101/921/199/101921199.geojson
+++ b/data/101/921/199/101921199.geojson
@@ -189,6 +189,9 @@
         "wk:page":"Tubas"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2635dcb5d927c57e39f4902930b9e395",
     "wof:hierarchy":[
         {
@@ -211,7 +214,7 @@
         }
     ],
     "wof:id":101921199,
-    "wof:lastmodified":1566600604,
+    "wof:lastmodified":1582314142,
     "wof:name":"Tubas",
     "wof:parent_id":1091913213,
     "wof:placetype":"locality",

--- a/data/101/921/241/101921241.geojson
+++ b/data/101/921/241/101921241.geojson
@@ -71,6 +71,9 @@
         "wk:page":"Kafr al-Labad"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b7c3c4d87d62932f6848e14ac9dad5e7",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":101921241,
-    "wof:lastmodified":1534985969,
+    "wof:lastmodified":1582314142,
     "wof:name":"Kafr al Labad",
     "wof:parent_id":1091913233,
     "wof:placetype":"locality",

--- a/data/101/921/287/101921287.geojson
+++ b/data/101/921/287/101921287.geojson
@@ -103,6 +103,9 @@
         "qs_pg:id":1297782
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"380a33f4cbe7b9445de6594e83a02af5",
     "wof:hierarchy":[
         {
@@ -125,7 +128,7 @@
         }
     ],
     "wof:id":101921287,
-    "wof:lastmodified":1566600589,
+    "wof:lastmodified":1582314142,
     "wof:name":"Sabastiya",
     "wof:parent_id":1091913091,
     "wof:placetype":"locality",

--- a/data/101/921/295/101921295.geojson
+++ b/data/101/921/295/101921295.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Tammun"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f66539f9118f59035411bcd25b6d79d1",
     "wof:hierarchy":[
         {
@@ -108,7 +111,7 @@
         }
     ],
     "wof:id":101921295,
-    "wof:lastmodified":1566600592,
+    "wof:lastmodified":1582314142,
     "wof:name":"Tammun",
     "wof:parent_id":1091913213,
     "wof:placetype":"locality",

--- a/data/101/921/387/101921387.geojson
+++ b/data/101/921/387/101921387.geojson
@@ -378,6 +378,9 @@
         "wk:page":"Nablus"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ae63b66b0ec04578b498dd236d2cfad6",
     "wof:hierarchy":[
         {
@@ -403,7 +406,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600616,
+    "wof:lastmodified":1582314143,
     "wof:name":"Nablus",
     "wof:parent_id":1091913091,
     "wof:placetype":"locality",

--- a/data/101/921/425/101921425.geojson
+++ b/data/101/921/425/101921425.geojson
@@ -83,6 +83,9 @@
         "wd:id":"Q2918718"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"5090b1068977c8ff18080b4faca964e8",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101921425,
-    "wof:lastmodified":1566600589,
+    "wof:lastmodified":1582314142,
     "wof:name":"Balata Camp",
     "wof:parent_id":1091913091,
     "wof:placetype":"locality",

--- a/data/101/921/471/101921471.geojson
+++ b/data/101/921/471/101921471.geojson
@@ -60,6 +60,9 @@
         "qs_pg:id":547120
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"f657a45f4b6eb38b1720eb4dda60a613",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":101921471,
-    "wof:lastmodified":1566600588,
+    "wof:lastmodified":1582314142,
     "wof:name":"Al Funduq",
     "wof:parent_id":1091913123,
     "wof:placetype":"locality",

--- a/data/101/921/513/101921513.geojson
+++ b/data/101/921/513/101921513.geojson
@@ -85,6 +85,9 @@
         "qs_pg:id":433146
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"faeb4b60b0c38182487a138b5491ffeb",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101921513,
-    "wof:lastmodified":1566600615,
+    "wof:lastmodified":1582314143,
     "wof:name":"'Azzun",
     "wof:parent_id":1091913123,
     "wof:placetype":"locality",

--- a/data/101/921/547/101921547.geojson
+++ b/data/101/921/547/101921547.geojson
@@ -80,6 +80,9 @@
         "wk:page":"Al-Jiftlik"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"953d1cbd38bdef66e46c704c1a7c3998",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101921547,
-    "wof:lastmodified":1566600614,
+    "wof:lastmodified":1582314142,
     "wof:name":"Al Jiftlik",
     "wof:parent_id":1091913007,
     "wof:placetype":"locality",

--- a/data/101/921/551/101921551.geojson
+++ b/data/101/921/551/101921551.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Kafr Thulth"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"b91cb8b83ce8b747249b40e3c8b5de63",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101921551,
-    "wof:lastmodified":1566600582,
+    "wof:lastmodified":1582314142,
     "wof:name":"Kafr Thulth",
     "wof:parent_id":1091913123,
     "wof:placetype":"locality",

--- a/data/101/921/655/101921655.geojson
+++ b/data/101/921/655/101921655.geojson
@@ -84,6 +84,9 @@
         "wd:id":"Q7424625"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"112976366824afbe90aa891d9b022094",
     "wof:hierarchy":[
         {
@@ -106,7 +109,7 @@
         }
     ],
     "wof:id":101921655,
-    "wof:lastmodified":1566600609,
+    "wof:lastmodified":1582314142,
     "wof:name":"Sarta",
     "wof:parent_id":1091913173,
     "wof:placetype":"locality",

--- a/data/101/921/665/101921665.geojson
+++ b/data/101/921/665/101921665.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Qabalan"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"3152cec82151975260db7d20f5c50ddc",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101921665,
-    "wof:lastmodified":1566600612,
+    "wof:lastmodified":1582314142,
     "wof:name":"Qabalan",
     "wof:parent_id":1091913091,
     "wof:placetype":"locality",

--- a/data/101/921/759/101921759.geojson
+++ b/data/101/921/759/101921759.geojson
@@ -76,6 +76,9 @@
         "wd:id":"Q7855610"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"615a8ee2f5a251f173d92fbdb13066bc",
     "wof:hierarchy":[
         {
@@ -88,7 +91,7 @@
         }
     ],
     "wof:id":101921759,
-    "wof:lastmodified":1561827631,
+    "wof:lastmodified":1582314142,
     "wof:name":"Turmus'ayya",
     "wof:parent_id":1091913137,
     "wof:placetype":"locality",

--- a/data/101/921/771/101921771.geojson
+++ b/data/101/921/771/101921771.geojson
@@ -71,6 +71,9 @@
         "wk:page":"Sinjil"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"a83b2957d5181bca0b5d624789f18a18",
     "wof:hierarchy":[
         {
@@ -83,7 +86,7 @@
         }
     ],
     "wof:id":101921771,
-    "wof:lastmodified":1534985971,
+    "wof:lastmodified":1582314142,
     "wof:name":"Sinjil",
     "wof:parent_id":1091913137,
     "wof:placetype":"locality",

--- a/data/101/921/791/101921791.geojson
+++ b/data/101/921/791/101921791.geojson
@@ -60,6 +60,9 @@
         "qs_pg:id":124009
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"316c47f191c66d3b9cd110903763069a",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
         }
     ],
     "wof:id":101921791,
-    "wof:lastmodified":1566600585,
+    "wof:lastmodified":1582314142,
     "wof:name":"Al Mughayyir",
     "wof:parent_id":1091913137,
     "wof:placetype":"locality",

--- a/data/101/921/839/101921839.geojson
+++ b/data/101/921/839/101921839.geojson
@@ -120,6 +120,9 @@
         "wd:id":"Q8046389"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"08d202e5323595bd881665eff3e0bc16",
     "wof:hierarchy":[
         {
@@ -142,7 +145,7 @@
         }
     ],
     "wof:id":101921839,
-    "wof:lastmodified":1566600612,
+    "wof:lastmodified":1582314142,
     "wof:name":"Yabrud",
     "wof:parent_id":1091913137,
     "wof:placetype":"locality",

--- a/data/101/921/867/101921867.geojson
+++ b/data/101/921/867/101921867.geojson
@@ -98,6 +98,9 @@
         "wk:page":"Silwad"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"ceb0b2d685bec24e19da20ca4da94bc6",
     "wof:hierarchy":[
         {
@@ -120,7 +123,7 @@
         }
     ],
     "wof:id":101921867,
-    "wof:lastmodified":1566600594,
+    "wof:lastmodified":1582314142,
     "wof:name":"Silwad",
     "wof:parent_id":1091913137,
     "wof:placetype":"locality",

--- a/data/101/921/975/101921975.geojson
+++ b/data/101/921/975/101921975.geojson
@@ -140,6 +140,9 @@
         "wd:id":"Q311326"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac07426f11b44029f799f72174f6707d",
     "wof:hierarchy":[
         {
@@ -162,7 +165,7 @@
         }
     ],
     "wof:id":101921975,
-    "wof:lastmodified":1566600618,
+    "wof:lastmodified":1582314143,
     "wof:name":"Al Bira",
     "wof:parent_id":1091913137,
     "wof:placetype":"locality",

--- a/data/101/922/001/101922001.geojson
+++ b/data/101/922/001/101922001.geojson
@@ -80,6 +80,9 @@
         "wk:page":"Kafr 'Aqab"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"ac6deb569fc32d46b21df6f951787081",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101922001,
-    "wof:lastmodified":1566600491,
+    "wof:lastmodified":1582314140,
     "wof:name":"Kafr 'Aqab",
     "wof:parent_id":1108720823,
     "wof:placetype":"locality",

--- a/data/101/922/027/101922027.geojson
+++ b/data/101/922/027/101922027.geojson
@@ -49,6 +49,9 @@
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"caab7955120ff303e34a738609a333f9",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":101922027,
-    "wof:lastmodified":1566600501,
+    "wof:lastmodified":1582314140,
     "wof:name":"Qalandiya Camp",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/101/922/029/101922029.geojson
+++ b/data/101/922/029/101922029.geojson
@@ -52,6 +52,9 @@
         "qs_pg:id":79889
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"a9e4ec4879c7fc0523d34a2727a15a4a",
     "wof:hierarchy":[
         {
@@ -63,7 +66,7 @@
         }
     ],
     "wof:id":101922029,
-    "wof:lastmodified":1566600502,
+    "wof:lastmodified":1582314140,
     "wof:name":"Qalandiya",
     "wof:parent_id":1108720823,
     "wof:placetype":"locality",

--- a/data/101/922/041/101922041.geojson
+++ b/data/101/922/041/101922041.geojson
@@ -102,6 +102,9 @@
         "wd:id":"Q94800"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"05c03756676e09176a316e890f608d1d",
     "wof:hierarchy":[
         {
@@ -124,7 +127,7 @@
         }
     ],
     "wof:id":101922041,
-    "wof:lastmodified":1566600481,
+    "wof:lastmodified":1582314140,
     "wof:name":"Qalandiya",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/101/922/085/101922085.geojson
+++ b/data/101/922/085/101922085.geojson
@@ -305,6 +305,9 @@
         "wd:id":"Q5687"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1b9b322d1a259e9cbf95e3c89bc70400",
     "wof:hierarchy":[
         {
@@ -327,7 +330,7 @@
         }
     ],
     "wof:id":101922085,
-    "wof:lastmodified":1566600484,
+    "wof:lastmodified":1582314140,
     "wof:name":"Jericho (Ariha)",
     "wof:parent_id":1091913007,
     "wof:placetype":"locality",

--- a/data/101/922/107/101922107.geojson
+++ b/data/101/922/107/101922107.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Beit Hanina"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"29a856dd83c83754548910eafada6b53",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101922107,
-    "wof:lastmodified":1566600497,
+    "wof:lastmodified":1582314140,
     "wof:name":"Beit Hanina",
     "wof:parent_id":1108720823,
     "wof:placetype":"locality",

--- a/data/101/922/113/101922113.geojson
+++ b/data/101/922/113/101922113.geojson
@@ -49,6 +49,9 @@
     "wof:breaches":[],
     "wof:concordances":{},
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"adda5a488f250c91d41f4c45f7488d1d",
     "wof:hierarchy":[
         {
@@ -71,7 +74,7 @@
         }
     ],
     "wof:id":101922113,
-    "wof:lastmodified":1566600514,
+    "wof:lastmodified":1582314141,
     "wof:name":"Ar Ram & Dahiyat al Bareed",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/101/922/123/101922123.geojson
+++ b/data/101/922/123/101922123.geojson
@@ -83,6 +83,9 @@
         "wk:page":"Hizma"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"98acb582d024a236c19eebb84ec2aca6",
     "wof:hierarchy":[
         {
@@ -105,7 +108,7 @@
         }
     ],
     "wof:id":101922123,
-    "wof:lastmodified":1566600510,
+    "wof:lastmodified":1582314141,
     "wof:name":"Hizma",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/101/922/131/101922131.geojson
+++ b/data/101/922/131/101922131.geojson
@@ -86,6 +86,9 @@
         "wk:page":"Beit Hanina"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"824c934b233a40402e9c6c629ef16c54",
     "wof:hierarchy":[
         {
@@ -97,7 +100,7 @@
         }
     ],
     "wof:id":101922131,
-    "wof:lastmodified":1566600496,
+    "wof:lastmodified":1582314140,
     "wof:name":"Beit Hanina",
     "wof:parent_id":1108720823,
     "wof:placetype":"locality",

--- a/data/101/922/153/101922153.geojson
+++ b/data/101/922/153/101922153.geojson
@@ -85,6 +85,9 @@
         "wk:page":"Hizma"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"2fa92b20cdc31e8502b8677d1e7dcc02",
     "wof:hierarchy":[
         {
@@ -107,7 +110,7 @@
         }
     ],
     "wof:id":101922153,
-    "wof:lastmodified":1566600495,
+    "wof:lastmodified":1582314140,
     "wof:name":"Hizma",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/101/922/177/101922177.geojson
+++ b/data/101/922/177/101922177.geojson
@@ -104,6 +104,9 @@
         "wk:page":"'Anata"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"82b8c1efe84cff8cac56c9da15b0dc48",
     "wof:hierarchy":[
         {
@@ -126,7 +129,7 @@
         }
     ],
     "wof:id":101922177,
-    "wof:lastmodified":1566600511,
+    "wof:lastmodified":1582314141,
     "wof:name":"'Anata",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/101/922/211/101922211.geojson
+++ b/data/101/922/211/101922211.geojson
@@ -80,6 +80,9 @@
         "wk:page":"At-Tur (Mount of Olives)"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"db09bb694fcd86f43d15a0d917dbf34f",
     "wof:hierarchy":[
         {
@@ -91,7 +94,7 @@
         }
     ],
     "wof:id":101922211,
-    "wof:lastmodified":1566600481,
+    "wof:lastmodified":1582314139,
     "wof:name":"At Tur",
     "wof:parent_id":1108720823,
     "wof:placetype":"locality",

--- a/data/101/922/221/101922221.geojson
+++ b/data/101/922/221/101922221.geojson
@@ -69,6 +69,9 @@
         "wk:page":"Ras al-Amud"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3b906d117f39bb1a72c7d05a88ffff68",
     "wof:hierarchy":[
         {
@@ -80,7 +83,7 @@
         }
     ],
     "wof:id":101922221,
-    "wof:lastmodified":1566600483,
+    "wof:lastmodified":1582314140,
     "wof:name":"Ras al 'Amud",
     "wof:parent_id":1108720823,
     "wof:placetype":"locality",

--- a/data/101/922/239/101922239.geojson
+++ b/data/101/922/239/101922239.geojson
@@ -152,6 +152,9 @@
         "wk:page":"Bethany (biblical village)"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"5cad454f57cfa9cfe75ad24322223c64",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":101922239,
-    "wof:lastmodified":1566600507,
+    "wof:lastmodified":1582314140,
     "wof:name":"Al 'Eizariya",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/101/922/245/101922245.geojson
+++ b/data/101/922/245/101922245.geojson
@@ -117,6 +117,9 @@
         "wk:page":"Abu Dis"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"42651408fb99de03f8e0ed8995acd8c5",
     "wof:hierarchy":[
         {
@@ -139,7 +142,7 @@
         }
     ],
     "wof:id":101922245,
-    "wof:lastmodified":1566600482,
+    "wof:lastmodified":1582314140,
     "wof:name":"Abu Dis",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/101/922/279/101922279.geojson
+++ b/data/101/922/279/101922279.geojson
@@ -118,6 +118,9 @@
         "wk:page":"Abu Dis"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c2609b98d2d7d23bcebbee3a6bc4a06b",
     "wof:hierarchy":[
         {
@@ -140,7 +143,7 @@
         }
     ],
     "wof:id":101922279,
-    "wof:lastmodified":1566600500,
+    "wof:lastmodified":1582314140,
     "wof:name":"Abu Dis",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/101/922/341/101922341.geojson
+++ b/data/101/922/341/101922341.geojson
@@ -445,6 +445,10 @@
         "wd:id":"Q5776"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"59c2791e67cdceef74152e619aac5889",
     "wof:hierarchy":[
         {
@@ -467,7 +471,7 @@
         }
     ],
     "wof:id":101922341,
-    "wof:lastmodified":1566600492,
+    "wof:lastmodified":1582314140,
     "wof:name":"Bethlehem (Beit Lahm)",
     "wof:parent_id":1091912933,
     "wof:placetype":"locality",

--- a/data/101/922/347/101922347.geojson
+++ b/data/101/922/347/101922347.geojson
@@ -129,6 +129,9 @@
         "wk:page":"Beit Jala"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"8f2b501c3515bf13d3395d1ba7abe6ef",
     "wof:hierarchy":[
         {
@@ -151,7 +154,7 @@
         }
     ],
     "wof:id":101922347,
-    "wof:lastmodified":1566600495,
+    "wof:lastmodified":1582314140,
     "wof:name":"Beit Jala",
     "wof:parent_id":1091912933,
     "wof:placetype":"locality",

--- a/data/101/922/629/101922629.geojson
+++ b/data/101/922/629/101922629.geojson
@@ -64,6 +64,9 @@
         "wd:id":"Q7067821"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e2f9271ab1977422431230acf80fe01f",
     "wof:hierarchy":[
         {
@@ -76,7 +79,7 @@
         }
     ],
     "wof:id":101922629,
-    "wof:lastmodified":1534985976,
+    "wof:lastmodified":1582314140,
     "wof:name":"Nuba",
     "wof:parent_id":1091912955,
     "wof:placetype":"locality",

--- a/data/101/922/677/101922677.geojson
+++ b/data/101/922/677/101922677.geojson
@@ -88,6 +88,9 @@
         "wd:id":"Q7395443"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"96e598902c263bd9792ac3c3d78404d1",
     "wof:hierarchy":[
         {
@@ -110,7 +113,7 @@
         }
     ],
     "wof:id":101922677,
-    "wof:lastmodified":1566600504,
+    "wof:lastmodified":1582314140,
     "wof:name":"Sa'ir",
     "wof:parent_id":1091912955,
     "wof:placetype":"locality",

--- a/data/101/922/699/101922699.geojson
+++ b/data/101/922/699/101922699.geojson
@@ -113,6 +113,9 @@
         "wk:page":"Halhul"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"926620c5344ab4aa9a54318d47786edf",
     "wof:hierarchy":[
         {
@@ -135,7 +138,7 @@
         }
     ],
     "wof:id":101922699,
-    "wof:lastmodified":1566600505,
+    "wof:lastmodified":1582314140,
     "wof:name":"Halhul",
     "wof:parent_id":1091912955,
     "wof:placetype":"locality",

--- a/data/101/922/757/101922757.geojson
+++ b/data/101/922/757/101922757.geojson
@@ -257,6 +257,7 @@
     "qs:type":"Built-Up Area",
     "src:geom":"quattroshapes",
     "src:geom_alt":[
+        "naturalearth",
         "quattroshapes_pg"
     ],
     "src:lbl:centroid":"mapshaper",
@@ -274,6 +275,10 @@
         "qs_pg:id":203676
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "naturalearth",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"1e1fb2cd8043a89690f19fc7c23633e3",
     "wof:hierarchy":[
         {
@@ -286,7 +291,7 @@
         }
     ],
     "wof:id":101922757,
-    "wof:lastmodified":1534985967,
+    "wof:lastmodified":1582314140,
     "wof:name":"Hebron (Al Khalil)",
     "wof:parent_id":1091912955,
     "wof:placetype":"locality",

--- a/data/101/922/793/101922793.geojson
+++ b/data/101/922/793/101922793.geojson
@@ -80,6 +80,9 @@
         "wk:page":"Qalqas"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"69bb9e2e1e356b1ba3ee5c5ec337a66a",
     "wof:hierarchy":[
         {
@@ -102,7 +105,7 @@
         }
     ],
     "wof:id":101922793,
-    "wof:lastmodified":1566600496,
+    "wof:lastmodified":1582314140,
     "wof:name":"Qalqas",
     "wof:parent_id":1091912955,
     "wof:placetype":"locality",

--- a/data/101/922/871/101922871.geojson
+++ b/data/101/922/871/101922871.geojson
@@ -131,6 +131,9 @@
         "wk:page":"Yatta, Hebron"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"e0fe1bb1c9670a7ff1a7073466764c5a",
     "wof:hierarchy":[
         {
@@ -153,7 +156,7 @@
         }
     ],
     "wof:id":101922871,
-    "wof:lastmodified":1566600502,
+    "wof:lastmodified":1582314140,
     "wof:name":"Yatta",
     "wof:parent_id":1091912955,
     "wof:placetype":"locality",

--- a/data/101/922/963/101922963.geojson
+++ b/data/101/922/963/101922963.geojson
@@ -89,6 +89,9 @@
         "wk:page":"Al-Karmil"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"2f357d7abd18fba7272c2630c6bce17e",
     "wof:hierarchy":[
         {
@@ -111,7 +114,7 @@
         }
     ],
     "wof:id":101922963,
-    "wof:lastmodified":1566600479,
+    "wof:lastmodified":1582314139,
     "wof:name":"Al Karmil",
     "wof:parent_id":1091912955,
     "wof:placetype":"locality",

--- a/data/109/191/293/3/1091912933.geojson
+++ b/data/109/191/293/3/1091912933.geojson
@@ -415,6 +415,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892684,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"41380c754c9ff6f4f507792733e4fbe4",
     "wof:hierarchy":[
         {
@@ -435,7 +438,7 @@
         }
     ],
     "wof:id":1091912933,
-    "wof:lastmodified":1566600468,
+    "wof:lastmodified":1582314137,
     "wof:name":"Bethlehem",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/295/5/1091912955.geojson
+++ b/data/109/191/295/5/1091912955.geojson
@@ -280,6 +280,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892685,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"9afe3982fec02cfc1f61323c4e456cfa",
     "wof:hierarchy":[
         {
@@ -300,7 +303,7 @@
         }
     ],
     "wof:id":1091912955,
-    "wof:lastmodified":1566600468,
+    "wof:lastmodified":1582314137,
     "wof:name":"Hebron",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/297/3/1091912973.geojson
+++ b/data/109/191/297/3/1091912973.geojson
@@ -169,6 +169,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892687,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"9f68b30cea306e246405efa140752bfb",
     "wof:hierarchy":[
         {
@@ -189,7 +192,7 @@
         }
     ],
     "wof:id":1091912973,
-    "wof:lastmodified":1566600469,
+    "wof:lastmodified":1582314138,
     "wof:name":"Jenin",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/300/7/1091913007.geojson
+++ b/data/109/191/300/7/1091913007.geojson
@@ -274,6 +274,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892690,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"5de39ed8dd6ba3aab6f80eff5df98215",
     "wof:hierarchy":[
         {
@@ -294,7 +297,7 @@
         }
     ],
     "wof:id":1091913007,
-    "wof:lastmodified":1566600467,
+    "wof:lastmodified":1582314136,
     "wof:name":"Jericho",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/309/1/1091913091.geojson
+++ b/data/109/191/309/1/1091913091.geojson
@@ -223,6 +223,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892692,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"9b7b3f9194cf5878498b4fef5c94af44",
     "wof:hierarchy":[
         {
@@ -243,7 +246,7 @@
         }
     ],
     "wof:id":1091913091,
-    "wof:lastmodified":1566600467,
+    "wof:lastmodified":1582314137,
     "wof:name":"Nablus",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/312/3/1091913123.geojson
+++ b/data/109/191/312/3/1091913123.geojson
@@ -148,6 +148,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892696,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"ce07eb2894722821f0984478ab779e47",
     "wof:hierarchy":[
         {
@@ -168,7 +171,7 @@
         }
     ],
     "wof:id":1091913123,
-    "wof:lastmodified":1566600469,
+    "wof:lastmodified":1582314137,
     "wof:name":"Qalqilya",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/313/7/1091913137.geojson
+++ b/data/109/191/313/7/1091913137.geojson
@@ -325,6 +325,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892698,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"043c9ce54081be8931bea08c0ee35360",
     "wof:hierarchy":[
         {
@@ -345,7 +348,7 @@
         }
     ],
     "wof:id":1091913137,
-    "wof:lastmodified":1566600469,
+    "wof:lastmodified":1582314137,
     "wof:name":"Ramallah",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/317/3/1091913173.geojson
+++ b/data/109/191/317/3/1091913173.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892700,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"50e87411116690c1c81e029678a6dc33",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":1091913173,
-    "wof:lastmodified":1566600470,
+    "wof:lastmodified":1582314138,
     "wof:name":"Salfit",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/321/3/1091913213.geojson
+++ b/data/109/191/321/3/1091913213.geojson
@@ -124,6 +124,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892701,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"2851ba5650aec76e6bcca3cd2a63f2ec",
     "wof:hierarchy":[
         {
@@ -144,7 +147,7 @@
         }
     ],
     "wof:id":1091913213,
-    "wof:lastmodified":1566600470,
+    "wof:lastmodified":1582314138,
     "wof:name":"Tubas",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/323/3/1091913233.geojson
+++ b/data/109/191/323/3/1091913233.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892703,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"8a54dbcd9c0853cd7bf0a9ef84bafd03",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":1091913233,
-    "wof:lastmodified":1566600469,
+    "wof:lastmodified":1582314137,
     "wof:name":"Tulkarm",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/326/7/1091913267.geojson
+++ b/data/109/191/326/7/1091913267.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892705,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"ed09be8c29bcab88a3434353dfdd1eb7",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":1091913267,
-    "wof:lastmodified":1566600470,
+    "wof:lastmodified":1582314138,
     "wof:name":"North Gaza",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/109/191/329/7/1091913297.geojson
+++ b/data/109/191/329/7/1091913297.geojson
@@ -154,6 +154,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892706,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"ddfe2affc281a8b0b357910cc47e6096",
     "wof:hierarchy":[
         {
@@ -174,7 +177,7 @@
         }
     ],
     "wof:id":1091913297,
-    "wof:lastmodified":1566600470,
+    "wof:lastmodified":1582314138,
     "wof:name":"Gaza",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/109/191/331/7/1091913317.geojson
+++ b/data/109/191/331/7/1091913317.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892708,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"7cbcd57d277f860422265da55bada44c",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":1091913317,
-    "wof:lastmodified":1566600468,
+    "wof:lastmodified":1582314137,
     "wof:name":"Deir Al-Balah",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/109/191/333/3/1091913333.geojson
+++ b/data/109/191/333/3/1091913333.geojson
@@ -70,6 +70,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892709,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"53d8fbdfd67c6666abc0787e986525dc",
     "wof:hierarchy":[
         {
@@ -90,7 +93,7 @@
         }
     ],
     "wof:id":1091913333,
-    "wof:lastmodified":1566600469,
+    "wof:lastmodified":1582314138,
     "wof:name":"Khan Younis",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/109/191/336/5/1091913365.geojson
+++ b/data/109/191/336/5/1091913365.geojson
@@ -190,6 +190,9 @@
     },
     "wof:country":"PS",
     "wof:created":1473892711,
+    "wof:geom_alt":[
+        "meso"
+    ],
     "wof:geomhash":"4763a6e295aeecfed70d95ff8f0d87f3",
     "wof:hierarchy":[
         {
@@ -210,7 +213,7 @@
         }
     ],
     "wof:id":1091913365,
-    "wof:lastmodified":1566600467,
+    "wof:lastmodified":1582314137,
     "wof:name":"Rafah",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/117/561/317/5/1175613175.geojson
+++ b/data/117/561/317/5/1175613175.geojson
@@ -89,6 +89,9 @@
         "wd:id":"Q2293751"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"eaeb61ba0b1e0728a86fe4c5d03036f9",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":1175613175,
-    "wof:lastmodified":1566600460,
+    "wof:lastmodified":1582314136,
     "wof:name":"Al Walaja",
     "wof:parent_id":1108720823,
     "wof:placetype":"locality",

--- a/data/117/561/320/9/1175613209.geojson
+++ b/data/117/561/320/9/1175613209.geojson
@@ -70,6 +70,9 @@
         "wd:id":"Q4804341"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6701afe52ca47e6e8fe5a87429f6d026",
     "wof:hierarchy":[
         {
@@ -92,7 +95,7 @@
         }
     ],
     "wof:id":1175613209,
-    "wof:lastmodified":1566600456,
+    "wof:lastmodified":1582314136,
     "wof:name":"Ash Sheikh Sa'd",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/117/561/324/1/1175613241.geojson
+++ b/data/117/561/324/1/1175613241.geojson
@@ -73,6 +73,9 @@
         "wd:id":"Q4831960"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"c4f623e4c4b6d8e925302bf35eb0cc3d",
     "wof:hierarchy":[
         {
@@ -95,7 +98,7 @@
         }
     ],
     "wof:id":1175613241,
-    "wof:lastmodified":1566600452,
+    "wof:lastmodified":1582314135,
     "wof:name":"Az Za'ayyem",
     "wof:parent_id":421200701,
     "wof:placetype":"locality",

--- a/data/117/561/335/9/1175613359.geojson
+++ b/data/117/561/335/9/1175613359.geojson
@@ -110,6 +110,9 @@
         "wd:id":"Q4696624"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"6ee664c920434bb35f1c389338036e35",
     "wof:hierarchy":[
         {
@@ -132,7 +135,7 @@
         }
     ],
     "wof:id":1175613359,
-    "wof:lastmodified":1566600455,
+    "wof:lastmodified":1582314136,
     "wof:name":"'Ayda Camp",
     "wof:parent_id":1091912933,
     "wof:placetype":"locality",

--- a/data/129/312/931/9/1293129319.geojson
+++ b/data/129/312/931/9/1293129319.geojson
@@ -78,6 +78,9 @@
         "wk:page":"Psagot"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "geonames"
+    ],
     "wof:geomhash":"2c63dd30c29de37e09d68dfca43e33c5",
     "wof:hierarchy":[
         {
@@ -100,7 +103,7 @@
         }
     ],
     "wof:id":1293129319,
-    "wof:lastmodified":1566600437,
+    "wof:lastmodified":1582314135,
     "wof:name":"Pesagot",
     "wof:parent_id":1091913137,
     "wof:placetype":"locality",

--- a/data/421/200/701/421200701.geojson
+++ b/data/421/200/701/421200701.geojson
@@ -221,7 +221,6 @@
     "qs:woe_id":24549736,
     "src:geom":"whosonfirst",
     "src:geom_alt":[
-        "quattroshapes",
         "quattroshapes"
     ],
     "src:geom_via":"quattroshapes",
@@ -255,6 +254,9 @@
     },
     "wof:country":"PS",
     "wof:created":1459010035,
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"40fec83af0698238c72707ea7bf72b21",
     "wof:hierarchy":[
         {
@@ -275,7 +277,7 @@
         }
     ],
     "wof:id":421200701,
-    "wof:lastmodified":1566600622,
+    "wof:lastmodified":1582314143,
     "wof:name":"Jerusalem",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/856/337/39/85633739.geojson
+++ b/data/856/337/39/85633739.geojson
@@ -754,8 +754,9 @@
     "src:geom":"whosonfirst",
     "src:geom_alt":[
         "naturalearth",
-        "meso",
-        "quattroshapes"
+        "quattroshapes",
+        "naturalearth",
+        "meso"
     ],
     "src:lbl_centroid":"mapshaper",
     "src:population":"geonames",
@@ -796,6 +797,12 @@
     },
     "wof:country":"PS",
     "wof:country_alpha3":"PSE",
+    "wof:geom_alt":[
+        "naturalearth-display-terrestrial-zoom6",
+        "quattroshapes",
+        "naturalearth",
+        "meso"
+    ],
     "wof:geomhash":"87d770b20e3be2d4fd0f412c118d6260",
     "wof:hierarchy":[
         {
@@ -810,7 +817,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566600429,
+    "wof:lastmodified":1582314134,
     "wof:name":"Palestine",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/337/39/85633739.geojson
+++ b/data/856/337/39/85633739.geojson
@@ -755,7 +755,6 @@
     "src:geom_alt":[
         "naturalearth",
         "quattroshapes",
-        "naturalearth",
         "meso"
     ],
     "src:lbl_centroid":"mapshaper",
@@ -817,7 +816,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1582314134,
+    "wof:lastmodified":1583200804,
     "wof:name":"Palestine",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/812/13/85681213.geojson
+++ b/data/856/812/13/85681213.geojson
@@ -524,6 +524,9 @@
         "wk:page":"Gaza Strip"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"413dea374240819cdd3bc08324b431f9",
     "wof:hierarchy":[
         {
@@ -548,7 +551,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566600434,
+    "wof:lastmodified":1582314134,
     "wof:name":"Gaza Strip",
     "wof:parent_id":1159339485,
     "wof:placetype":"region",

--- a/data/856/814/27/85681427.geojson
+++ b/data/856/814/27/85681427.geojson
@@ -475,6 +475,9 @@
         "wk:page":"West Bank"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"aad5c9dbc9d709392653160bb01db03c",
     "wof:hierarchy":[
         {
@@ -499,7 +502,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1566600435,
+    "wof:lastmodified":1582314135,
     "wof:name":"West Bank",
     "wof:parent_id":1159339487,
     "wof:placetype":"region",

--- a/data/859/071/29/85907129.geojson
+++ b/data/859/071/29/85907129.geojson
@@ -86,6 +86,9 @@
         "wd:id":"Q2916530"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"e32fddbcb71f3d3f9d5d7f6ebbd0c398",
     "wof:hierarchy":[
         {
@@ -101,7 +104,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600426,
+    "wof:lastmodified":1582314133,
     "wof:name":"Giv'at Shapira",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/31/85907131.geojson
+++ b/data/859/071/31/85907131.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":8165
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"8dc4433e0ead3d6aab3558c92f9d7fbb",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600426,
+    "wof:lastmodified":1582314133,
     "wof:name":"Tsameret Ha-bira",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/37/85907137.geojson
+++ b/data/859/071/37/85907137.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1085675
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes",
+        "quattroshapes_pg"
+    ],
     "wof:geomhash":"aab06685a63a38aa674e31ba7b24408f",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600427,
+    "wof:lastmodified":1582314133,
     "wof:name":"A-tur",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/39/85907139.geojson
+++ b/data/859/071/39/85907139.geojson
@@ -68,6 +68,10 @@
         "qs_pg:id":1085676
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"c8712046819261564aff6ff2fd12b6b4",
     "wof:hierarchy":[
         {
@@ -83,7 +87,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600427,
+    "wof:lastmodified":1582314133,
     "wof:name":"Silwan Kfar Ha-shilo'akh",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/41/85907141.geojson
+++ b/data/859/071/41/85907141.geojson
@@ -71,6 +71,10 @@
         "qs_pg:id":1085677
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"ec7484e45c24b1f395b39df5e44d3e3a",
     "wof:hierarchy":[
         {
@@ -98,7 +102,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600427,
+    "wof:lastmodified":1582314133,
     "wof:name":"Khirbet Beit Sakhur",
     "wof:parent_id":101922245,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/43/85907143.geojson
+++ b/data/859/071/43/85907143.geojson
@@ -100,6 +100,9 @@
         "qs_pg:id":212393
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"9e37d220da803f9b9a8076143c59f88e",
     "wof:hierarchy":[
         {
@@ -115,7 +118,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600426,
+    "wof:lastmodified":1582314133,
     "wof:name":"Jabel Mukabir",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/47/85907147.geojson
+++ b/data/859/071/47/85907147.geojson
@@ -67,6 +67,9 @@
         "qs_pg:id":1187531
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"85ae6cba9a60926f1e01a1e73d2ebc43",
     "wof:hierarchy":[
         {
@@ -82,7 +85,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600428,
+    "wof:lastmodified":1582314133,
     "wof:name":"Mizrakh Talpiyot",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/49/85907149.geojson
+++ b/data/859/071/49/85907149.geojson
@@ -92,6 +92,10 @@
         "qs_pg:id":1187523
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"6c75ddc541d8cd5fc3daaadaec28efab",
     "wof:hierarchy":[
         {
@@ -107,7 +111,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600427,
+    "wof:lastmodified":1582314133,
     "wof:name":"Sur Baher",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/57/85907157.geojson
+++ b/data/859/071/57/85907157.geojson
@@ -153,6 +153,10 @@
         "wd:id":"Q1781931"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"3735524862fd76249cf4eb3abd032cc2",
     "wof:hierarchy":[
         {
@@ -168,7 +172,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600426,
+    "wof:lastmodified":1582314133,
     "wof:name":"Moslem Quarter",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/65/85907165.geojson
+++ b/data/859/071/65/85907165.geojson
@@ -86,6 +86,10 @@
         "qs_pg:id":1087565
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"2f39b7f8c5d1d74b41de7bde9748f123",
     "wof:hierarchy":[
         {
@@ -101,7 +105,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600427,
+    "wof:lastmodified":1582314133,
     "wof:name":"Wadi Al-joz",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/67/85907167.geojson
+++ b/data/859/071/67/85907167.geojson
@@ -70,6 +70,9 @@
         "qs_pg:id":1087566
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"fdbf4bad345de6f1d3b1f2683db64343",
     "wof:hierarchy":[
         {
@@ -85,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600426,
+    "wof:lastmodified":1582314133,
     "wof:name":"Ha-moshava Ha-amerika'it",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/071/71/85907171.geojson
+++ b/data/859/071/71/85907171.geojson
@@ -99,6 +99,9 @@
         "wd:id":"Q2916125"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"3082f74d7dc26476038a62fab39befb5",
     "wof:hierarchy":[
         {
@@ -114,7 +117,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600427,
+    "wof:lastmodified":1582314133,
     "wof:name":"Kiryat Ha-memshala",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/29/85907229.geojson
+++ b/data/859/072/29/85907229.geojson
@@ -113,6 +113,9 @@
         "wd:id":"Q1524664"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes"
+    ],
     "wof:geomhash":"404de97965aba5e527295f3f6f3326a7",
     "wof:hierarchy":[
         {
@@ -128,7 +131,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600428,
+    "wof:lastmodified":1582314133,
     "wof:name":"Gilo",
     "wof:parent_id":421168681,
     "wof:placetype":"neighbourhood",

--- a/data/859/072/35/85907235.geojson
+++ b/data/859/072/35/85907235.geojson
@@ -97,6 +97,10 @@
         "wd:id":"Q1028231"
     },
     "wof:country":"PS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"7341754b394f57c1bf658ccca1a5330d",
     "wof:hierarchy":[
         {
@@ -124,7 +128,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566600428,
+    "wof:lastmodified":1582314133,
     "wof:name":"Pisgat Ze'ev",
     "wof:parent_id":101922113,
     "wof:placetype":"neighbourhood",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.