### PR TITLE
ps concordances, placetype local, and more

### DIFF
--- a/data/109/191/293/3/1091912933.geojson
+++ b/data/109/191/293/3/1091912933.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.061633,
-    "geom:area_square_m":648871321.63108,
+    "geom:area_square_m":648871480.26852,
     "geom:bbox":"35.04883,31.463121,35.481675,31.744763",
     "geom:latitude":31.632878,
     "geom:longitude":35.295711,
@@ -416,12 +416,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.BL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892684,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"2de97ba66670b351e047843939141b01",
+    "wof:geomhash":"2cbc49d8278f96d7161c55cd56db7571",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -441,7 +442,7 @@
         }
     ],
     "wof:id":1091912933,
-    "wof:lastmodified":1642551756,
+    "wof:lastmodified":1695886510,
     "wof:name":"Bethlehem",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/295/5/1091912955.geojson
+++ b/data/109/191/295/5/1091912955.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.094552,
-    "geom:area_square_m":996992651.164669,
+    "geom:area_square_m":996992598.683641,
     "geom:bbox":"34.880274,31.342602,35.355859,31.670944",
     "geom:latitude":31.488181,
     "geom:longitude":35.092066,
@@ -278,12 +278,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.HE"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892685,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"a5e9c72bc4575c1e2af79a8310ce4aff",
+    "wof:geomhash":"df62d00bbfae1899783b7046aa32ba56",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -303,7 +304,7 @@
         }
     ],
     "wof:id":1091912955,
-    "wof:lastmodified":1617131441,
+    "wof:lastmodified":1695886620,
     "wof:name":"Hebron",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/297/3/1091912973.geojson
+++ b/data/109/191/297/3/1091912973.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.055861,
-    "geom:area_square_m":583053741.494757,
+    "geom:area_square_m":583053569.876085,
     "geom:bbox":"35.07203,32.300298,35.428696,32.552088",
     "geom:latitude":32.42282,
     "geom:longitude":35.255922,
@@ -167,12 +167,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.JN"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892687,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"0b2e1712851d358c860119aa828ef4a3",
+    "wof:geomhash":"2e329051a43ee8c1b1bfcdb6bfead15e",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -192,7 +193,7 @@
         }
     ],
     "wof:id":1091912973,
-    "wof:lastmodified":1617129939,
+    "wof:lastmodified":1695886571,
     "wof:name":"Jenin",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/300/7/1091913007.geojson
+++ b/data/109/191/300/7/1091913007.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.056885,
-    "geom:area_square_m":596712836.898732,
+    "geom:area_square_m":596712836.898911,
     "geom:bbox":"35.361586513,31.740400398,35.569580738,32.195995063",
     "geom:latitude":31.968186,
     "geom:longitude":35.472898,
@@ -272,12 +272,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.JC"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892690,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"5de39ed8dd6ba3aab6f80eff5df98215",
+    "wof:geomhash":"66735933e4323dc433c0eeeb38d8488d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -297,7 +298,7 @@
         }
     ],
     "wof:id":1091913007,
-    "wof:lastmodified":1582314136,
+    "wof:lastmodified":1695886423,
     "wof:name":"Jericho",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/309/1/1091913091.geojson
+++ b/data/109/191/309/1/1091913091.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.057853,
-    "geom:area_square_m":605448946.651069,
+    "geom:area_square_m":605448946.650595,
     "geom:bbox":"35.138201411,32.033056936,35.470923958,32.325658927",
     "geom:latitude":32.183095,
     "geom:longitude":35.298128,
@@ -221,12 +221,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.NA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892692,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"9b7b3f9194cf5878498b4fef5c94af44",
+    "wof:geomhash":"9a6018e6618d4cc8ae74a8287be28195",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -246,7 +247,7 @@
         }
     ],
     "wof:id":1091913091,
-    "wof:lastmodified":1582314137,
+    "wof:lastmodified":1695886423,
     "wof:name":"Nablus",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/312/3/1091913123.geojson
+++ b/data/109/191/312/3/1091913123.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.015913,
-    "geom:area_square_m":166535741.691049,
+    "geom:area_square_m":166535752.187444,
     "geom:bbox":"34.957012,32.107316,35.194954,32.25447",
     "geom:latitude":32.183818,
     "geom:longitude":35.068613,
@@ -146,12 +146,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.QA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892696,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"65f3bca7281e96b0b72393f2b7e86596",
+    "wof:geomhash":"2d4c3ba304bdc72088f559ed016c01cf",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -171,7 +172,7 @@
         }
     ],
     "wof:id":1091913123,
-    "wof:lastmodified":1617131168,
+    "wof:lastmodified":1695886611,
     "wof:name":"Qalqilya",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/313/7/1091913137.geojson
+++ b/data/109/191/313/7/1091913137.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.077392,
-    "geom:area_square_m":811909306.768749,
+    "geom:area_square_m":811909301.703172,
     "geom:bbox":"34.979027,31.828959,35.431373,32.069738",
     "geom:latitude":31.95956,
     "geom:longitude":35.206823,
@@ -323,12 +323,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.RB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892698,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"15830f3e8f443d9c033ccaa6218945d6",
+    "wof:geomhash":"7aa660fc74b1b5c75582d0ceca54ff81",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -348,7 +349,7 @@
         }
     ],
     "wof:id":1091913137,
-    "wof:lastmodified":1617130939,
+    "wof:lastmodified":1695886607,
     "wof:name":"Ramallah",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/317/3/1091913173.geojson
+++ b/data/109/191/317/3/1091913173.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.019463,
-    "geom:area_square_m":203863518.338653,
+    "geom:area_square_m":203863518.338666,
     "geom:bbox":"34.982891,32.045637088,35.262762438,32.178942878",
     "geom:latitude":32.104293,
     "geom:longitude":35.111694,
@@ -122,12 +122,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.SA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892700,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"50e87411116690c1c81e029678a6dc33",
+    "wof:geomhash":"29ac84611e660b0adf3b883880e260e5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1091913173,
-    "wof:lastmodified":1582314138,
+    "wof:lastmodified":1695886424,
     "wof:name":"Salfit",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/321/3/1091913213.geojson
+++ b/data/109/191/321/3/1091913213.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.038569,
-    "geom:area_square_m":403096849.477895,
+    "geom:area_square_m":403096810.708523,
     "geom:bbox":"35.317118,32.176221,35.574052,32.412915",
     "geom:latitude":32.303364,
     "geom:longitude":35.464258,
@@ -122,12 +122,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.TB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892701,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"7e2dd8968d23c994b3d978ea822250bc",
+    "wof:geomhash":"955db0706073e56be0a4b0b27e12b7dd",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -147,7 +148,7 @@
         }
     ],
     "wof:id":1091913213,
-    "wof:lastmodified":1617129862,
+    "wof:lastmodified":1695886557,
     "wof:name":"Tubas",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/323/3/1091913233.geojson
+++ b/data/109/191/323/3/1091913233.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023626,
-    "geom:area_square_m":246896355.166589,
+    "geom:area_square_m":246896288.551609,
     "geom:bbox":"35.007263,32.196713,35.168476,32.458208",
     "geom:latitude":32.313303,
     "geom:longitude":35.083081,
@@ -152,12 +152,13 @@
     "wof:concordances":{
         "hasc:id":"PS.WE.TL"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892703,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"8349b9c54bacda4b719f25615495db21",
+    "wof:geomhash":"168aae0f0606200aa320e9bcfe253849",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -177,7 +178,7 @@
         }
     ],
     "wof:id":1091913233,
-    "wof:lastmodified":1617130011,
+    "wof:lastmodified":1695886579,
     "wof:name":"Tulkarm",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/109/191/326/7/1091913267.geojson
+++ b/data/109/191/326/7/1091913267.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005783,
-    "geom:area_square_m":60941445.035669,
+    "geom:area_square_m":60941435.292572,
     "geom:bbox":"34.452267,31.49884,34.5678,31.594539",
     "geom:latitude":31.544148,
     "geom:longitude":34.509673,
@@ -71,12 +71,13 @@
     "wof:concordances":{
         "hasc:id":"PS.GZ.GS"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892705,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"34ae0e3c5ec8ba9f360765c4e387b729",
+    "wof:geomhash":"52d712d791f30f8d078e0e44078bd6c6",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091913267,
-    "wof:lastmodified":1627522519,
+    "wof:lastmodified":1695886163,
     "wof:name":"North Gaza",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/109/191/329/7/1091913297.geojson
+++ b/data/109/191/329/7/1091913297.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.007176,
-    "geom:area_square_m":75670443.990468,
+    "geom:area_square_m":75670481.204155,
     "geom:bbox":"34.375751,31.427833,34.51194,31.547039",
     "geom:latitude":31.488316,
     "geom:longitude":34.445547,
@@ -155,12 +155,13 @@
     "wof:concordances":{
         "hasc:id":"PS.GZ.GZ"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892706,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"1bb1b380525f367091ffbb4187e60be6",
+    "wof:geomhash":"25a7e2e207707d44d4fdcae14fbb4ba5",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -180,7 +181,7 @@
         }
     ],
     "wof:id":1091913297,
-    "wof:lastmodified":1636494852,
+    "wof:lastmodified":1695886621,
     "wof:name":"Gaza",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/109/191/331/7/1091913317.geojson
+++ b/data/109/191/331/7/1091913317.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.005649,
-    "geom:area_square_m":59607368.238975,
+    "geom:area_square_m":59607327.911046,
     "geom:bbox":"34.297417,31.374341,34.426462,31.467056",
     "geom:latitude":31.420629,
     "geom:longitude":34.369337,
@@ -71,12 +71,13 @@
     "wof:concordances":{
         "hasc:id":"PS.GZ.DB"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892708,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"8406411de1a89c0f392b940086617635",
+    "wof:geomhash":"14e0f247f9010930cdc7256f9545867c",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091913317,
-    "wof:lastmodified":1627522519,
+    "wof:lastmodified":1695886163,
     "wof:name":"Deir Al-Balah",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/109/191/333/3/1091913333.geojson
+++ b/data/109/191/333/3/1091913333.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.010124,
-    "geom:area_square_m":106924069.586168,
+    "geom:area_square_m":106924110.974599,
     "geom:bbox":"34.245853,31.260867,34.3735,31.394583",
     "geom:latitude":31.336443,
     "geom:longitude":34.318941,
@@ -71,12 +71,13 @@
     "wof:concordances":{
         "hasc:id":"PS.GZ.KY"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892709,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"6b00952e42f9ae49fe54528f38fff164",
+    "wof:geomhash":"8fd383896537cdcb872fae01db8f412d",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -96,7 +97,7 @@
         }
     ],
     "wof:id":1091913333,
-    "wof:lastmodified":1627522519,
+    "wof:lastmodified":1695886163,
     "wof:name":"Khan Younis",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/109/191/336/5/1091913365.geojson
+++ b/data/109/191/336/5/1091913365.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.006098,
-    "geom:area_square_m":64445275.029603,
+    "geom:area_square_m":64445118.458653,
     "geom:bbox":"34.218699,31.220052,34.330752,31.346631",
     "geom:latitude":31.282949,
     "geom:longitude":34.27276,
@@ -188,12 +188,13 @@
     "wof:concordances":{
         "hasc:id":"PS.GZ.RA"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1473892711,
     "wof:geom_alt":[
         "meso"
     ],
-    "wof:geomhash":"4b7923a441d6c3853c5f8c5bfabd5122",
+    "wof:geomhash":"22a7262cd20f58a0697daff58b1c5140",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -213,7 +214,7 @@
         }
     ],
     "wof:id":1091913365,
-    "wof:lastmodified":1617131522,
+    "wof:lastmodified":1695886621,
     "wof:name":"Rafah",
     "wof:parent_id":85681213,
     "wof:placetype":"county",

--- a/data/421/200/701/421200701.geojson
+++ b/data/421/200/701/421200701.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.026816,
-    "geom:area_square_m":281795159.056393,
+    "geom:area_square_m":281795110.241328,
     "geom:bbox":"35.082937,31.716372,35.491788,31.88656",
     "geom:latitude":31.804462,
     "geom:longitude":35.289121,
@@ -294,12 +294,13 @@
         "qs_pg:id":891888,
         "wd:id":"Q192232"
     },
+    "wof:concordances_official":"hasc:id",
     "wof:country":"PS",
     "wof:created":1459010035,
     "wof:geom_alt":[
         "quattroshapes"
     ],
-    "wof:geomhash":"3dae20d1f0e5fed6f412452994bf89a0",
+    "wof:geomhash":"87166e5451b6522911d8021e89e072ca",
     "wof:hierarchy":[
         {
             "continent_id":102191569,
@@ -319,7 +320,7 @@
         }
     ],
     "wof:id":421200701,
-    "wof:lastmodified":1690856015,
+    "wof:lastmodified":1695886621,
     "wof:name":"Jerusalem",
     "wof:parent_id":85681427,
     "wof:placetype":"county",

--- a/data/856/337/39/85633739.geojson
+++ b/data/856/337/39/85633739.geojson
@@ -1023,12 +1023,14 @@
         "hasc:id":"PS",
         "icao:code":"SU-Y",
         "ioc:id":"PLE",
+        "iso:code":"PS",
         "m49:code":"275",
         "ne:adm0_a3":"PSX",
         "ne:id":1159320899,
         "qs_pg:id":616321,
         "wd:id":"Q219060"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PS",
     "wof:country_alpha3":"PSE",
     "wof:geom_alt":[
@@ -1051,7 +1053,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694639679,
+    "wof:lastmodified":1695881337,
     "wof:name":"Palestine",
     "wof:parent_id":102191569,
     "wof:placetype":"country",

--- a/data/856/812/13/85681213.geojson
+++ b/data/856/812/13/85681213.geojson
@@ -532,6 +532,7 @@
         "gn:id":281132,
         "gp:id":23424838,
         "hasc:id":"PS.GZ",
+        "iso:code":"PS-GZZ",
         "iso:id":"PS-GZZ",
         "marc:id":"gz",
         "nyt:id":"N49255557356717107211",
@@ -539,6 +540,7 @@
         "wd:id":"Q762573",
         "wk:page":"Gaza Strip"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PS",
     "wof:geom_alt":[
         "quattroshapes"
@@ -567,7 +569,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493129,
+    "wof:lastmodified":1695884331,
     "wof:name":"Gaza Strip",
     "wof:parent_id":1159339485,
     "wof:placetype":"region",

--- a/data/856/814/27/85681427.geojson
+++ b/data/856/814/27/85681427.geojson
@@ -518,6 +518,7 @@
         "gn:id":285153,
         "gp:id":23424988,
         "hasc:id":"PS.WE",
+        "iso:code":"PS-WBK",
         "iso:id":"PS-WBK",
         "marc:id":"wj",
         "nyt:id":"63257233507740230531",
@@ -525,6 +526,7 @@
         "wd:id":"Q36678",
         "wk:page":"West Bank"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"PS",
     "wof:geom_alt":[
         "quattroshapes"
@@ -553,7 +555,7 @@
     "wof:lang_x_spoken":[
         "ara"
     ],
-    "wof:lastmodified":1694493255,
+    "wof:lastmodified":1695884778,
     "wof:name":"West Bank",
     "wof:parent_id":1159339487,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.